### PR TITLE
NAS-137796 / 26.04 / Encode CSR before sending to OpenSSL

### DIFF
--- a/pytest/unit/test_private_key.py
+++ b/pytest/unit/test_private_key.py
@@ -8,15 +8,23 @@ from truenas_crypto_utils.read import load_private_key
 
 
 @pytest.mark.parametrize('generate_params,expected_type,key_size', [
-    ({}, rsa.RSAPrivateKey, 2048),
-    ({'type': 'EC'}, ec.EllipticCurvePrivateKey, 384),
+    (
+        {},
+        rsa.RSAPrivateKey,
+        2048,
+    ),
+    (
+        {'type': 'EC'},
+        ec.EllipticCurvePrivateKey,
+        384,
+    ),
     (
         {
             'type': 'RSA',
             'key_length': 4096,
         },
         rsa.RSAPrivateKey,
-        4096
+        4096,
     ),
 ])
 def test_generating_private_key(generate_params, expected_type, key_size):

--- a/truenas_acme_utils/issue_cert.py
+++ b/truenas_acme_utils/issue_cert.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def issue_certificate(
     acme_client_key_payload: ACMEClientAndKeyData, csr: bytes, authenticator_mapping_copy: dict, progress_base: int = 25
-):
+) -> messages.OrderResource:
     # Authenticator mapping should be a valid mapping of domain to authenticator object
     acme_client, key = get_acme_client_and_key(acme_client_key_payload)
     try:

--- a/truenas_acme_utils/issue_cert.py
+++ b/truenas_acme_utils/issue_cert.py
@@ -6,7 +6,7 @@ import logging
 import josepy as jose
 from acme import errors, messages
 
-from .client_utils import get_acme_client_and_key
+from .client_utils import ACMEClientAndKeyData, get_acme_client_and_key
 from .event import send_event
 from .exceptions import CallError
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def issue_certificate(
-    acme_client_key_payload: dict, csr: str, authenticator_mapping_copy: dict, progress_base: int = 25
+    acme_client_key_payload: ACMEClientAndKeyData, csr: bytes, authenticator_mapping_copy: dict, progress_base: int = 25
 ):
     # Authenticator mapping should be a valid mapping of domain to authenticator object
     acme_client, key = get_acme_client_and_key(acme_client_key_payload)

--- a/truenas_acme_utils/issue_cert.py
+++ b/truenas_acme_utils/issue_cert.py
@@ -15,13 +15,13 @@ logger = logging.getLogger(__name__)
 
 
 def issue_certificate(
-    acme_client_key_payload: ACMEClientAndKeyData, csr: bytes, authenticator_mapping_copy: dict, progress_base: int = 25
+    acme_client_key_payload: ACMEClientAndKeyData, csr: str, authenticator_mapping_copy: dict, progress_base: int = 25
 ) -> messages.OrderResource:
     # Authenticator mapping should be a valid mapping of domain to authenticator object
     acme_client, key = get_acme_client_and_key(acme_client_key_payload)
     try:
         # perform operations and have a cert issued
-        order = acme_client.new_order(csr)
+        order = acme_client.new_order(csr.encode())
     except messages.Error as e:
         raise CallError(f'Failed to issue a new order for Certificate : {e}')
     else:

--- a/truenas_crypto_utils/csr.py
+++ b/truenas_crypto_utils/csr.py
@@ -7,7 +7,7 @@ from .key import export_private_key_object, generate_private_key, retrieve_signi
 from .utils import CERT_BACKEND_MAPPINGS, EC_CURVE_DEFAULT
 
 
-def generate_certificate_signing_request(data: dict) -> tuple[str, str]:
+def generate_certificate_signing_request(data: dict) -> tuple[bytes, str]:
     key = generate_private_key({
         'type': data.get('key_type') or 'RSA',
         'curve': data.get('ec_curve') or EC_CURVE_DEFAULT,
@@ -27,4 +27,4 @@ def generate_certificate_signing_request(data: dict) -> tuple[str, str]:
     csr = add_extensions(csr, data.get('cert_extensions', {}), key, None)
     csr = csr.sign(key, retrieve_signing_algorithm(data, key), default_backend())
 
-    return csr.public_bytes(serialization.Encoding.PEM).decode(), export_private_key_object(key)
+    return csr.public_bytes(serialization.Encoding.PEM), export_private_key_object(key)

--- a/truenas_crypto_utils/csr.py
+++ b/truenas_crypto_utils/csr.py
@@ -7,7 +7,7 @@ from .key import export_private_key_object, generate_private_key, retrieve_signi
 from .utils import CERT_BACKEND_MAPPINGS, EC_CURVE_DEFAULT
 
 
-def generate_certificate_signing_request(data: dict) -> tuple[bytes, str]:
+def generate_certificate_signing_request(data: dict) -> tuple[str, str]:
     key = generate_private_key({
         'type': data.get('key_type') or 'RSA',
         'curve': data.get('ec_curve') or EC_CURVE_DEFAULT,
@@ -27,4 +27,4 @@ def generate_certificate_signing_request(data: dict) -> tuple[bytes, str]:
     csr = add_extensions(csr, data.get('cert_extensions', {}), key, None)
     csr = csr.sign(key, retrieve_signing_algorithm(data, key), default_backend())
 
-    return csr.public_bytes(serialization.Encoding.PEM), export_private_key_object(key)
+    return csr.public_bytes(serialization.Encoding.PEM).decode(), export_private_key_object(key)

--- a/truenas_crypto_utils/generate_certs.py
+++ b/truenas_crypto_utils/generate_certs.py
@@ -40,7 +40,7 @@ def generate_certificate(data: dict) -> tuple[str, str]:
     else:
         issuer = None
 
-    cert = add_extensions(generate_builder(builder_data), data.get('cert_extensions'), key, issuer)
+    cert = add_extensions(generate_builder(builder_data), data.get('cert_extensions', {}), key, issuer)
 
     cert = cert.sign(
         ca_key or key, retrieve_signing_algorithm(data, ca_key or key), default_backend()

--- a/truenas_crypto_utils/generate_self_signed.py
+++ b/truenas_crypto_utils/generate_self_signed.py
@@ -21,7 +21,6 @@ def generate_self_signed_certificate() -> tuple[str, str]:
         'san': normalize_san(['localhost'])
     })
     key = generate_private_key({
-        'serialize': False,
         'key_length': 2048,
         'type': 'RSA'
     })

--- a/truenas_crypto_utils/generate_utils.py
+++ b/truenas_crypto_utils/generate_utils.py
@@ -53,7 +53,7 @@ def generate_builder(options: dict) -> x509.CertificateBuilder | x509.Certificat
     return cert
 
 
-def normalize_san(san_list: list) -> list:
+def normalize_san(san_list: list[str] | None) -> list[list[str]]:
     # TODO: ADD MORE TYPES WRT RFC'S
     normalized = []
     for count, san in enumerate(san_list or []):

--- a/truenas_crypto_utils/key.py
+++ b/truenas_crypto_utils/key.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypeAlias, overload
+from typing import Literal, overload
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey
@@ -7,12 +7,8 @@ from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 
-from .read import load_private_key
+from .read import GeneratedPrivateKey, PrivateKey, load_private_key
 from .utils import EC_CURVE_DEFAULT
-
-
-GeneratedPrivateKey: TypeAlias = Ed25519PrivateKey | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey
-PrivateKey: TypeAlias = GeneratedPrivateKey | Ed448PrivateKey | DSAPrivateKey
 
 
 def retrieve_signing_algorithm(data: dict, signing_key: PrivateKey):

--- a/truenas_crypto_utils/key.py
+++ b/truenas_crypto_utils/key.py
@@ -1,9 +1,7 @@
 from typing import Literal, overload
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 

--- a/truenas_crypto_utils/key.py
+++ b/truenas_crypto_utils/key.py
@@ -1,5 +1,9 @@
-from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, ed448, rsa
+from typing import Literal, TypeAlias, overload
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 
@@ -7,51 +11,52 @@ from .read import load_private_key
 from .utils import EC_CURVE_DEFAULT
 
 
-def retrieve_signing_algorithm(data: dict, signing_key: (
-    ed25519.Ed25519PrivateKey |
-    ed448.Ed448PrivateKey |
-    rsa.RSAPrivateKey |
-    dsa.DSAPrivateKey |
-    ec.EllipticCurvePrivateKey
-)):
+GeneratedPrivateKey: TypeAlias = Ed25519PrivateKey | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey
+PrivateKey: TypeAlias = GeneratedPrivateKey | Ed448PrivateKey | DSAPrivateKey
+
+
+def retrieve_signing_algorithm(
+    data: dict,
+    signing_key: PrivateKey,
+):
     if isinstance(signing_key, Ed25519PrivateKey):
         return None
     else:
         return getattr(hashes, data.get('digest_algorithm') or 'SHA256')()
 
 
-def generate_private_key(options: dict) -> (
-    str,
-    ed25519.Ed25519PrivateKey |
-    ed448.Ed448PrivateKey |
-    rsa.RSAPrivateKey |
-    dsa.DSAPrivateKey |
-    ec.EllipticCurvePrivateKey
-):
+@overload
+def generate_private_key(options: dict, *, serialize: Literal[True]) -> str: ...
+
+
+@overload
+def generate_private_key(options: dict, *, serialize: Literal[False] = False) -> GeneratedPrivateKey: ...
+
+
+def generate_private_key(options: dict, *, serialize: bool = False) -> GeneratedPrivateKey | str:
     # We should make sure to return in PEM format
     # Reason for using PKCS8
     # https://stackoverflow.com/questions/48958304/pkcs1-and-pkcs8-format-for-rsa-private-key
-    options.setdefault('serialize', False)
     options.setdefault('key_length', 2048)
     options.setdefault('type', 'RSA')
     options.setdefault('curve', EC_CURVE_DEFAULT)
 
-    if options.get('type') == 'EC':
+    if options['type'] == 'EC':
         if options['curve'] == 'ed25519':
             key = Ed25519PrivateKey.generate()
         else:
             key = ec.generate_private_key(
-                getattr(ec, options.get('curve')),
+                getattr(ec, options['curve'])(),
                 default_backend()
             )
     else:
         key = rsa.generate_private_key(
             public_exponent=65537,
-            key_size=options.get('key_length'),
+            key_size=options['key_length'],
             backend=default_backend()
         )
 
-    if options.get('serialize'):
+    if serialize:
         return key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
@@ -67,13 +72,7 @@ def export_private_key(buffer: str, passphrase: str | None = None) -> str | None
         return export_private_key_object(key)
 
 
-def export_private_key_object(key: (
-    ed25519.Ed25519PrivateKey |
-    ed448.Ed448PrivateKey |
-    rsa.RSAPrivateKey |
-    dsa.DSAPrivateKey |
-    ec.EllipticCurvePrivateKey
-)) -> str:
+def export_private_key_object(key: PrivateKey) -> str:
     return key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,

--- a/truenas_crypto_utils/key.py
+++ b/truenas_crypto_utils/key.py
@@ -15,10 +15,7 @@ GeneratedPrivateKey: TypeAlias = Ed25519PrivateKey | rsa.RSAPrivateKey | ec.Elli
 PrivateKey: TypeAlias = GeneratedPrivateKey | Ed448PrivateKey | DSAPrivateKey
 
 
-def retrieve_signing_algorithm(
-    data: dict,
-    signing_key: PrivateKey,
-):
+def retrieve_signing_algorithm(data: dict, signing_key: PrivateKey):
     if isinstance(signing_key, Ed25519PrivateKey):
         return None
     else:

--- a/truenas_crypto_utils/read.py
+++ b/truenas_crypto_utils/read.py
@@ -127,7 +127,7 @@ def parse_name_components(obj: crypto.X509Name) -> str:
     return f'/{"/".join(dn)}'
 
 
-def load_certificate_request(csr: str) -> dict:
+def load_certificate_request(csr: bytes) -> dict:
     try:
         csr_obj = crypto.load_certificate_request(crypto.FILETYPE_PEM, csr)
     except crypto.Error:


### PR DESCRIPTION
We ultimately need this to be in bytes form for the ACME package (see ticket).

This is part of the fallout from upgrading to trixie, specifically from `acme` upgrading from 2.11.0 to 4.0.0. This significantly changed the behavior of `acme.client.ClientV2.new_order`.

2.11.0 executed this helpful statement in the `OpenSSL` package:
```python
    if isinstance(buffer, str):
        buffer = buffer.encode("ascii")
```

whereas 4.0.0 passes `csr_pem` directly to the `cryptography` module instead:
```python
        csr = x509.load_pem_x509_csr(csr_pem)
```

However, even 2.11.0 specified that a `bytes` argument should have been passed instead of a string.

This will require changes in two other repositories:
- https://github.com/truenas/middleware/pull/17313
- https://github.com/truenas/truenas_connect_utils/pull/12