### PR TITLE
NAS-140159 / 27.0.0-BETA.1 / Make sure to include order url in exception

### DIFF
--- a/truenas_acme_utils/issue_cert.py
+++ b/truenas_acme_utils/issue_cert.py
@@ -61,6 +61,10 @@ def issue_certificate(
                             '\n- Details: ' \
                             f'{challenge.error.detail if challenge.error else "No error details were found"}\n\n'
                 raise CallError(f'Certificate request for final order failed: {msg}')
+        except Exception as e:
+            if hasattr(e, 'extra') and e.extra is None:
+                e.extra = {'order_uri': order.uri}
+            raise
         finally:
             cleanup_authorizations(order, authenticator_mapping, key)
 


### PR DESCRIPTION
This commit adds changes to ensure that we include order url in exception if there is a failure so any consumer consuming this can potentially get more visibility on what might have happened.