### PR TITLE
NAS-141013 / 26.0.0-RC.1 / Split ACME authorization polling and order finalization (by sonicaj)

### DIFF
--- a/pytest/unit/test_issue_cert.py
+++ b/pytest/unit/test_issue_cert.py
@@ -1,0 +1,134 @@
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from acme import errors, messages
+
+import truenas_acme_utils.issue_cert as ic
+from truenas_acme_utils.exceptions import CallError
+
+
+def make_order(uri='https://acme.test/order/1', identifiers=('example.com',)):
+    body = SimpleNamespace(identifiers=[SimpleNamespace(value=v) for v in identifiers])
+    return SimpleNamespace(uri=uri, body=body)
+
+
+def make_failed_authzr(identifier='example.com'):
+    challenge = SimpleNamespace(
+        chall=SimpleNamespace(typ='dns-01'),
+        error=SimpleNamespace(typ='urn:ietf:params:acme:error:dns', detail='no TXT record found'),
+    )
+    return SimpleNamespace(body=SimpleNamespace(identifier=identifier, challenges=[challenge]))
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Patch issue_cert module globals so issue_certificate runs against a fake ACME client."""
+    order = make_order()
+    client = MagicMock()
+    client.poll_authorizations.return_value = order
+    client.finalize_order.return_value = order
+    cleanup = MagicMock()
+
+    monkeypatch.setattr(ic, 'get_acme_client_and_key', lambda payload: (client, object()))
+    monkeypatch.setattr(ic, 'acme_order', lambda *a, **k: order)
+    monkeypatch.setattr(ic, 'handle_authorizations', lambda *a, **k: None)
+    monkeypatch.setattr(ic, 'cleanup_authorizations', cleanup)
+    monkeypatch.setattr(ic, 'send_event', lambda *a, **k: None)
+
+    return SimpleNamespace(order=order, client=client, cleanup=cleanup)
+
+
+def call():
+    return ic.issue_certificate({}, 'csr-pem', {'DNS:example.com': object()})
+
+
+def test_happy_path(env):
+    assert call() is env.order
+    env.client.poll_authorizations.assert_called_once()
+    env.client.finalize_order.assert_called_once()
+    env.cleanup.assert_called_once()
+
+
+def test_authz_timeout(env):
+    env.client.poll_authorizations.side_effect = errors.TimeoutError()
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'authorization phase' in exc.value.errmsg
+    env.client.finalize_order.assert_not_called()
+    env.cleanup.assert_called_once()
+    assert exc.value.extra == {'order_uri': env.order.uri}
+
+
+def test_finalize_timeout(env):
+    env.client.finalize_order.side_effect = errors.TimeoutError()
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'finalize phase' in exc.value.errmsg
+    env.cleanup.assert_called_once()
+    assert exc.value.extra == {'order_uri': env.order.uri}
+
+
+def test_validation_error(env):
+    env.client.poll_authorizations.side_effect = errors.ValidationError([make_failed_authzr()])
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'final order failed' in exc.value.errmsg
+    assert 'example.com' in exc.value.errmsg
+    assert 'no TXT record found' in exc.value.errmsg
+    env.cleanup.assert_called_once()
+
+
+def test_finalize_invalid(env):
+    env.client.finalize_order.side_effect = errors.IssuanceError(messages.Error.with_code('serverInternal'))
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'final order failed' in exc.value.errmsg
+    env.cleanup.assert_called_once()
+
+
+def test_finalize_rate_limited(env):
+    env.client.finalize_order.side_effect = messages.Error.with_code('rateLimited', detail='slow down')
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'rate limited' in exc.value.errmsg
+    assert 'will not help' in exc.value.errmsg
+    env.cleanup.assert_called_once()
+
+
+def test_order_placement_error(env, monkeypatch):
+    def boom(*a, **k):
+        raise messages.Error(detail='nope')
+
+    monkeypatch.setattr(ic, 'acme_order', boom)
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'Failed to issue a new order' in exc.value.errmsg
+    env.cleanup.assert_not_called()
+
+
+def test_order_placement_rate_limited(env, monkeypatch):
+    def boom(*a, **k):
+        raise messages.Error.with_code('rateLimited', detail='slow down')
+
+    monkeypatch.setattr(ic, 'acme_order', boom)
+    with pytest.raises(CallError) as exc:
+        call()
+    assert 'rate limited' in exc.value.errmsg
+    env.cleanup.assert_not_called()
+
+
+def test_deadlines_independent(env):
+    before = datetime.datetime.now()
+    call()
+    after = datetime.datetime.now()
+
+    authz_deadline = env.client.poll_authorizations.call_args.args[1]
+    finalize_deadline = env.client.finalize_order.call_args.args[1]
+
+    # Each phase gets its own ~5 minute window computed at call time.
+    assert before + ic.ACME_AUTHZ_TIMEOUT <= authz_deadline <= after + ic.ACME_AUTHZ_TIMEOUT
+    assert before + ic.ACME_FINALIZE_TIMEOUT <= finalize_deadline <= after + ic.ACME_FINALIZE_TIMEOUT
+    # finalize deadline is computed after authorizations finish, so it is a fresh, later window.
+    assert finalize_deadline > authz_deadline

--- a/truenas_acme_utils/client_utils.py
+++ b/truenas_acme_utils/client_utils.py
@@ -1,10 +1,14 @@
 import json
+import logging
 import time
 import typing
 
 import josepy as jose
 from acme import client, crypto_util, messages
 from cryptography import x509
+
+
+logger = logging.getLogger('acme')
 
 
 class NewOrder(messages.NewOrder):
@@ -119,6 +123,11 @@ def acme_order(
                         continue
 
                 raise
+
+    logger.info(
+        'ACME order created (uri=%s) for identifiers: %s',
+        response.headers.get('Location'), ', '.join(i.value for i in body.identifiers),
+    )
 
     return messages.OrderResource(
         body=body,

--- a/truenas_acme_utils/issue_cert.py
+++ b/truenas_acme_utils/issue_cert.py
@@ -11,7 +11,14 @@ from .event import send_event
 from .exceptions import CallError
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('acme')
+
+# Each phase gets its own independently-computed deadline so finalize receives a fresh window
+# after authorizations complete (acme.client.poll_and_finalize shares a single deadline between
+# the two). ZeroSSL/Boulder validate and issue in ~2 minutes, so 5 minutes per phase is ~2.5x
+# normal: fail-fast with margin. Tune here if a CA proves slower.
+ACME_AUTHZ_TIMEOUT = datetime.timedelta(minutes=5)
+ACME_FINALIZE_TIMEOUT = datetime.timedelta(minutes=5)
 
 
 def issue_certificate(
@@ -25,8 +32,15 @@ def issue_certificate(
         # perform operations and have a cert issued
         order = acme_order(acme_client, csr.encode(), cert_renewal_id)
     except messages.Error as e:
+        if messages.is_acme_error(e) and e.code == 'rateLimited':
+            raise CallError(
+                f'ACME server rate limited the new order request: {e}. Retrying immediately will not help; '
+                'please wait for the rate limit window to reset before requesting this certificate again.'
+            )
         raise CallError(f'Failed to issue a new order for Certificate : {e}')
     else:
+        identifiers = [i.value for i in order.body.identifiers]
+        logger.info('ACME order placed (uri=%r) for identifiers: %s', order.uri, ', '.join(identifiers))
         send_event(progress_base, 'New order for certificate issuance placed')
 
         authenticator_mapping = {}
@@ -40,14 +54,17 @@ def issue_certificate(
         try:
             handle_authorizations(progress_base, order, authenticator_mapping, acme_client, key)
 
+            # poll_and_finalize of acme lib bundles authorization polling and order finalization under a single
+            # deadline and raises an indistinguishable timeout for either. We split them so each phase
+            # has its own deadline and a failure names the phase that actually hung.
+            logger.info('Entering authorization polling phase for order %r', order.uri)
             try:
-                # Polling for a maximum of 10 minutes while trying to finalize order
-                # Should we try .poll() instead first ? research please
-                return acme_client.poll_and_finalize(
-                    order, datetime.datetime.now() + datetime.timedelta(minutes=10)
-                )
+                order = acme_client.poll_authorizations(order, datetime.datetime.now() + ACME_AUTHZ_TIMEOUT)
             except errors.TimeoutError:
-                raise CallError('Certificate request for final order timed out')
+                raise CallError(
+                    'Certificate request timed out during the authorization phase '
+                    f'(no response within {int(ACME_AUTHZ_TIMEOUT.total_seconds() // 60)} minutes)'
+                )
             except errors.ValidationError as e:
                 msg = ''
                 for authzr in e.failed_authzrs:
@@ -61,6 +78,35 @@ def issue_certificate(
                             '\n- Details: ' \
                             f'{challenge.error.detail if challenge.error else "No error details were found"}\n\n'
                 raise CallError(f'Certificate request for final order failed: {msg}')
+
+            logger.info('Entering finalize phase for order %r', order.uri)
+            try:
+                order = acme_client.finalize_order(order, datetime.datetime.now() + ACME_FINALIZE_TIMEOUT)
+            except errors.TimeoutError:
+                raise CallError(
+                    'Certificate request timed out during the finalize phase '
+                    f'(no certificate issued within {int(ACME_FINALIZE_TIMEOUT.total_seconds() // 60)} minutes)'
+                )
+            except errors.IssuanceError as e:
+                logger.info('Finalize failed (order invalid) for order %r: %s', order.uri, e)
+                raise CallError(f'Certificate request for final order failed: {e}')
+            except messages.Error as e:
+                if messages.is_acme_error(e) and e.code == 'rateLimited':
+                    raise CallError(
+                        f'ACME server rate limited the finalize request: {e}. Retrying immediately will not '
+                        'help; please wait for the rate limit window to reset before requesting this '
+                        'certificate again.'
+                    )
+                detail = getattr(e, 'detail', None) or str(e)
+                logger.info('Finalize failed for order %r: %s', order.uri, detail)
+                raise CallError(f'Certificate request for final order failed: {detail}')
+
+            logger.info('Certificate issued successfully for order %r', order.uri)
+            return order
+        except Exception as e:
+            if hasattr(e, 'extra') and e.extra is None:
+                e.extra = {'order_uri': order.uri}
+            raise
         finally:
             cleanup_authorizations(order, authenticator_mapping, key)
 


### PR DESCRIPTION
This commit adds changes to replace the single poll_and_finalize call with separate poll_authorizations and finalize_order calls, each with its own deadline, so a timeout names whether the authorization or the finalize phase hung instead of failing opaquely after one shared 10 minute wait. It also reports rate-limited responses clearly rather than as a generic order failure, and routes ACME issuance diagnostics (order URIs, identifiers, phase transitions) to a dedicated 'acme' logger.

Original PR: https://github.com/truenas/truenas_crypto_utils/pull/17
